### PR TITLE
Remove `chmod 777 Kayla.NET-Linux` instruction from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Download `Kayla.NET-Win64.exe` from Releases and run.
 ### Linux
 Download `Kayla.NET-Linux` from Releases and run following commands:
 ```
-$ chmod 777 Kayla.NET-Linux
 $ chmod +x Kayla.NET-Linux
 $ ./Kayla.NET-Linux
 ```


### PR DESCRIPTION
```bash
wget https://github.com/Cryental/Kayla.NET/releases/download/v1.2.2/Kayla.NET-Linux
ls -lh Kayla.NET-Linux
```
```
-rw-r--r-- 1 benjamin benjamin 76M Dec  7  2021 Kayla.NET-Linux
```

```bash
chmod 777 Kayla.NET-Linux
ls -lh Kayla.NET-Linux
```
```
-rwxrwxrwx 1 benjamin benjamin 76M Dec  7  2021 Kayla.NET-Linux
```

```bash
chmod +x Kayla.NET-Linux
ls -lh Kayla.NET-Linux
```
```
-rwxrwxrwx 1 benjamin benjamin 76M Dec  7  2021 Kayla.NET-Linux
```